### PR TITLE
fix(api): manage launch import job api endpoint options

### DIFF
--- a/src/services/api/jobs-api.service.spec.ts
+++ b/src/services/api/jobs-api.service.spec.ts
@@ -40,5 +40,17 @@ describe('JobsApi', () => {
       expect(mockHttpClient.post).toHaveBeenCalledWith('/api/rest/v1/jobs/import/job_123', {});
       expect(result).toEqual(mockResponse);
     });
+
+    it('should call the endpoint with options if provided', async () => {
+      const mockResponse: LaunchJobResponse = { execution_id: 'exec_3' };
+      mockHttpClient.post.mockResolvedValue({ data: mockResponse });
+
+      const result = await api.launchImportJob(testCode, { import_mode: 'create_or_update' });
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/api/rest/v1/jobs/import/job_123', {
+        import_mode: 'create_or_update',
+      });
+      expect(result).toEqual(mockResponse);
+    });
   });
 });

--- a/src/services/api/jobs-api.service.ts
+++ b/src/services/api/jobs-api.service.ts
@@ -4,6 +4,10 @@ export type LaunchJobResponse = {
   execution_id: string;
 };
 
+export type LaunchImportJobOptions = {
+  import_mode?: 'create_only' | 'update_only' | 'create_or_update';
+};
+
 export class JobsApi {
   private readonly endpoint = '/api/rest/v1/jobs';
 
@@ -13,7 +17,7 @@ export class JobsApi {
     return this.client.httpClient.post(`${this.endpoint}/export/${code}`, {}).then((response) => response.data);
   }
 
-  async launchImportJob(code: string): Promise<LaunchJobResponse> {
-    return this.client.httpClient.post(`${this.endpoint}/import/${code}`, {}).then((response) => response.data);
+  async launchImportJob(code: string, options: LaunchImportJobOptions = {}): Promise<LaunchJobResponse> {
+    return this.client.httpClient.post(`${this.endpoint}/import/${code}`, options).then((response) => response.data);
   }
 }

--- a/tests/jobs.e2e-spec.ts
+++ b/tests/jobs.e2e-spec.ts
@@ -34,6 +34,14 @@ describe('JobsApi E2E', () => {
     expect(result).toEqual(mockResponse);
   });
 
+  it('should launch an import job with options', async () => {
+    const mockResponse: LaunchJobResponse = { execution_id: 'exec_import_2' };
+    nock(baseUrl).post('/api/rest/v1/jobs/import/job_789', { import_mode: 'update_only' }).reply(200, mockResponse);
+
+    const result = await akeneoClient.jobs.launchImportJob('job_789', { import_mode: 'update_only' });
+    expect(result).toEqual(mockResponse);
+  });
+
   it('should handle API errors gracefully', async () => {
     nock(baseUrl).post('/api/rest/v1/jobs/export/nonexistent').reply(404, { code: 404, message: 'Not found' });
 


### PR DESCRIPTION
This pull request enhances the `JobsApi` service by adding support for optional parameters when launching import jobs.

**Related documentation**: https://api.akeneo.com/api-reference.html#post_job_import